### PR TITLE
Update requirement and tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'wagtail>=1.11.1,<2.2',
+    'wagtail>=1.11.1,<2.3',
 ]
 
 setup_requirements = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
-envlist = py{36}-wt{111,20}, flake8
+envlist = py{37}-wt{111,20}, flake8
 
 [testenv]
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 install_command = pip install -e ".[test]" -U {opts} {packages}
 commands = ./runtests.sh
 deps =
-    wt20: wagtail>=2.0,<2.1
+    wt20: wagtail>=2.0,<2.3
     wt111: wagtail>=1.11.1,>1.12
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
For one of my projects (which requires wagtail>=2.2) i wanted to use wagtail-app-pages. However, the current requirements state that a wagtail version of <2.2 is required. I ran tox with the updated settings  (see tox.ini changes) and it succeeded. So hereby I would like to update the requirements.