### PR TITLE
Add Wagtail 2.12 and 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,38 @@ matrix:
       sudo: true
       dist: xenial
 
+  # Wagtail 2.10
+    - env: TOXENV=py36-wt210
+      python: 3.6
+    - env: TOXENV=py37-wt210
+      python: 3.7
+      sudo: true
+      dist: xenial
+
+  # Wagtail 2.11
+    - env: TOXENV=py36-wt211
+      python: 3.6
+    - env: TOXENV=py37-wt211
+      python: 3.7
+      sudo: true
+      dist: xenial
+
+  # Wagtail 2.12
+    - env: TOXENV=py36-wt212
+      python: 3.6
+    - env: TOXENV=py37-wt212
+      python: 3.7
+      sudo: true
+      dist: xenial
+
+  # Wagtail 2.13
+    - env: TOXENV=py36-wt213
+      python: 3.6
+    - env: TOXENV=py37-wt213
+      python: 3.7
+      sudo: true
+      dist: xenial
+
   # Flake 8
     - env: TOXENV=flake8
       python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@
 
 from setuptools import setup, find_packages
 
-with open('README.md') as readme_file:
+with open("README.md") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    'wagtail>=1.11.1,<2.12',
+    "wagtail>=1.11.1,<2.14",
 ]
 
 setup_requirements = []
@@ -21,31 +21,31 @@ test_requirements = []
 
 setup(
     author="Marco Westerhof",
-    author_email='westerhof.marco@gmail.com',
+    author_email="westerhof.marco@gmail.com",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     description="Full MVC support for wagtail pages",
     install_requires=requirements,
     license="MIT license",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     include_package_data=True,
-    keywords='wagtail_app_pages',
-    name='wagtail_app_pages',
-    packages=find_packages(include=['wagtail_app_pages']),
+    keywords="wagtail_app_pages",
+    name="wagtail_app_pages",
+    packages=find_packages(include=["wagtail_app_pages"]),
     setup_requires=setup_requirements,
-    test_suite='tests.testproject.testproject.tests',
+    test_suite="tests.testproject.testproject.tests",
     tests_require=test_requirements,
-    url='https://github.com/mwesterhof/wagtail_app_pages',
-    version='0.2.17',
+    url="https://github.com/mwesterhof/wagtail_app_pages",
+    version="0.2.17",
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37}-wt{111,20,21,22,23,24,25,26,27,28,29,210,211}, flake8
+envlist = py{37}-wt{111,20,21,22,23,24,25,26,27,28,29,210,211,212,213}, flake8
 
 [testenv]
 basepython =
@@ -20,6 +20,8 @@ deps =
     wt29: wagtail>=2.9,<2.10
     wt210: wagtail>=2.10,<2.11
     wt211: wagtail>=2.11,<2.12
+    wt212: wagtail>=2.12,<2.13
+    wt213: wagtail>=2.13,<2.14
     wt111: wagtail>=1.11.1,<1.12
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Add support for wagtail 2.12 / 2.13. Also enables CI for 2.10 and 2.11, as that was missing.