### PR TITLE
Fix app name in AppConfig

### DIFF
--- a/wagtail_app_pages/apps.py
+++ b/wagtail_app_pages/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class AppPagesConfig(AppConfig):
-    name = 'app_pages'
+    name = 'wagtail_app_pages'


### PR DESCRIPTION
Adds compatibility for Django >= 2.3

This class wasn't actually used prior to Django 2.3 because `default_app_config` was missing from the package `__init__.py` file. Once autodetection from Django 2.3 was enabled, this class is used. This results in a conflict, because the name is expected to be equal to the fully qualified package name.